### PR TITLE
#16 - Add meta field to the json response.

### DIFF
--- a/resources/serializers.py
+++ b/resources/serializers.py
@@ -11,13 +11,22 @@ from .models import (
     Starship,
 )
 
+class MetaSerializer(serializers.HyperlinkedModelSerializer):
+    class Meta:
+      abstract=True
 
-class PeopleSerializer(serializers.HyperlinkedModelSerializer):
+    meta = serializers.SerializerMethodField()
+
+    def get_meta(self, obj):
+      return { "created": obj.created, "edited": obj.edited }
+
+class PeopleSerializer(MetaSerializer):
 
     homeworld = serializers.HyperlinkedRelatedField(
         read_only=True,
         view_name="planet-detail"
     )
+
 
     class Meta:
         model = People
@@ -35,13 +44,13 @@ class PeopleSerializer(serializers.HyperlinkedModelSerializer):
             "species",
             "vehicles",
             "starships",
-            "created",
-            "edited",
             "url",
+            "meta"
         )
 
 
-class PlanetSerializer(serializers.HyperlinkedModelSerializer):
+
+class PlanetSerializer(MetaSerializer):
 
     class Meta:
         model = Planet
@@ -57,13 +66,12 @@ class PlanetSerializer(serializers.HyperlinkedModelSerializer):
             "population",
             "residents",
             "films",
-            "created",
-            "edited",
-            "url"
+            "url",
+            "meta"
         )
 
 
-class FilmSerializer(serializers.HyperlinkedModelSerializer):
+class FilmSerializer(MetaSerializer):
 
     class Meta:
         model = Film
@@ -79,13 +87,12 @@ class FilmSerializer(serializers.HyperlinkedModelSerializer):
             "starships",
             "vehicles",
             "species",
-            "created",
-            "edited",
-            "url"
+            "url",
+            "meta"
         )
 
 
-class SpeciesSerializer(serializers.HyperlinkedModelSerializer):
+class SpeciesSerializer(MetaSerializer):
 
     homeworld = serializers.HyperlinkedRelatedField(
         read_only=True,
@@ -107,13 +114,12 @@ class SpeciesSerializer(serializers.HyperlinkedModelSerializer):
             "language",
             "people",
             "films",
-            "created",
-            "edited",
-            "url"
+            "url",
+            "meta"
         )
 
 
-class VehicleSerializer(serializers.HyperlinkedModelSerializer):
+class VehicleSerializer(MetaSerializer):
 
     pilots = serializers.HyperlinkedRelatedField(
         many=True,
@@ -137,13 +143,12 @@ class VehicleSerializer(serializers.HyperlinkedModelSerializer):
             "vehicle_class",
             "pilots",
             "films",
-            "created",
-            "edited",
-            "url"
+            "url",
+            "meta"
         )
 
 
-class StarshipSerializer(serializers.HyperlinkedModelSerializer):
+class StarshipSerializer(MetaSerializer):
 
     pilots = serializers.HyperlinkedRelatedField(
         many=True,
@@ -169,8 +174,7 @@ class StarshipSerializer(serializers.HyperlinkedModelSerializer):
             "starship_class",
             "pilots",
             "films",
-            "created",
-            "edited",
-            "url"
+            "url",
+            "meta"
         )
 

--- a/resources/tests.py
+++ b/resources/tests.py
@@ -12,6 +12,9 @@ from .models import (
 )
 
 from .renderers import WookieeRenderer
+from datetime import datetime
+from django.utils import timezone
+
 
 import json
 
@@ -82,12 +85,23 @@ class TestAllEndpoints(TestCase):
         self.assertEqual(
             self.get_query("/api/species/schema").status_code, 200)
 
+    def get_timezone_aware_datetime(self, date_string):
+        return timezone.make_aware(datetime.strptime(date_string, '%Y-%m-%dT%H:%M:%S.%fZ'), timezone.get_current_timezone())
+
     def test_people_detail(self):
         response = self.get_query("/api/people/1/")
         json_data = json.loads(response.content)
         person = People.objects.get(pk=1)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(person.name, json_data["name"])
+
+    def test_people_meta_detail(self):
+        response = self.get_query("/api/people/1/")
+        json_data = json.loads(response.content)
+        person = People.objects.get(pk=1)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(person.created, self.get_timezone_aware_datetime(json_data["meta"]["created"]))
+        self.assertEqual(person.edited, self.get_timezone_aware_datetime(json_data["meta"]["edited"]))
 
     def test_planets_detail(self):
         response = self.get_query("/api/planets/1/")
@@ -96,12 +110,28 @@ class TestAllEndpoints(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(planet.name, json_data["name"])
 
+    def test_planet_meta_detail(self):
+        response = self.get_query("/api/planets/1/")
+        json_data = json.loads(response.content)
+        planet = Planet.objects.get(pk=1)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(planet.created, self.get_timezone_aware_datetime(json_data["meta"]["created"]))
+        self.assertEqual(planet.edited, self.get_timezone_aware_datetime(json_data["meta"]["edited"]))
+
     def test_films_detail(self):
         response = self.get_query("/api/films/1/")
         json_data = json.loads(response.content)
         film = Film.objects.get(pk=1)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(film.title, json_data["title"])
+
+    def test_film_meta_detail(self):
+        response = self.get_query("/api/films/1/")
+        json_data = json.loads(response.content)
+        film = Film.objects.get(pk=1)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(film.created, self.get_timezone_aware_datetime(json_data["meta"]["created"]))
+        self.assertEqual(film.edited, self.get_timezone_aware_datetime(json_data["meta"]["edited"]))
 
     def test_starships_detail(self):
         response = self.get_query("/api/starships/2/")
@@ -110,6 +140,14 @@ class TestAllEndpoints(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(starship.name, json_data["name"])
 
+    def test_starship_meta_detail(self):
+        response = self.get_query("/api/starships/2/")
+        json_data = json.loads(response.content)
+        starship = Starship.objects.get(pk=2)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(starship.created, self.get_timezone_aware_datetime(json_data["meta"]["created"]))
+        self.assertEqual(starship.edited, self.get_timezone_aware_datetime(json_data["meta"]["edited"]))
+
     def test_vehicles_detail(self):
         response = self.get_query("/api/vehicles/4/")
         json_data = json.loads(response.content)
@@ -117,12 +155,28 @@ class TestAllEndpoints(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(vehicle.name, json_data["name"])
 
+    def test_vehicle_meta_detail(self):
+        response = self.get_query("/api/vehicles/4/")
+        json_data = json.loads(response.content)
+        vehicle = Vehicle.objects.get(pk=4)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(vehicle.created, self.get_timezone_aware_datetime(json_data["meta"]["created"]))
+        self.assertEqual(vehicle.edited, self.get_timezone_aware_datetime(json_data["meta"]["edited"]))
+
     def test_species_detail(self):
         response = self.get_query("/api/species/1/")
         json_data = json.loads(response.content)
         specie = Species.objects.get(pk=1)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(specie.name, json_data["name"])
+
+    def test_species_meta_detail(self):
+        response = self.get_query("/api/species/1/")
+        json_data = json.loads(response.content)
+        species = Species.objects.get(pk=1)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(species.created, self.get_timezone_aware_datetime(json_data["meta"]["created"]))
+        self.assertEqual(species.edited, self.get_timezone_aware_datetime(json_data["meta"]["edited"]))
 
     def test_etag(self):
         valid_etag = self.get_query("/api/")["ETag"]
@@ -147,3 +201,4 @@ class TestAllEndpoints(TestCase):
             wr.translate_to_wookie(specie.name),
             json_data[wr.translate_to_wookie("name")]
         )
+


### PR DESCRIPTION
Hey!  This would be my first contribution.  I was able to modify how the response is serialized to be formatted as follows:

{
    "name": "Luke Skywalker", 
    "height": "172", 
    "mass": "77", 
    "hair_color": "blond", 
    "skin_color": "fair", 
    "eye_color": "blue", 
    "birth_year": "19BBY", 
    "gender": "male", 
    "homeworld": "http://localhost:8000/api/planets/1/", 
    "films": [
        "http://localhost:8000/api/films/1/", 
        "http://localhost:8000/api/films/2/", 
        "http://localhost:8000/api/films/3/", 
        "http://localhost:8000/api/films/6/"
    ], 
    "species": [], 
    "vehicles": [
        "http://localhost:8000/api/vehicles/14/", 
        "http://localhost:8000/api/vehicles/30/"
    ], 
    "starships": [
        "http://localhost:8000/api/starships/12/", 
        "http://localhost:8000/api/starships/22/"
    ], 
    "url": "http://localhost:8000/api/people/1/", 
    "meta": {
        "edited": "2014-12-20T21:17:56.891Z", 
        "created": "2014-12-09T13:50:51.644Z"
    }

Please let me know if there is anything more/less I should do.  Look forward to helping more if possible.