### PR TITLE
Adding Elixir wrapper to list of helpers

### DIFF
--- a/swapi/templates/docs.md
+++ b/swapi/templates/docs.md
@@ -682,3 +682,7 @@ There are a bunch of helper libraries available for consuming the Star Wars API 
 ## F# #
 
 - [fsharp-swapi](https://github.com/evelinag/fsharp-swapi) by [Evelina Gabasova](http://evelinag.com/).
+
+## Elixir
+
+- [swapi.ex](https://github.com/twhitacre/swapi.ex) by [Tim Whitacre](http://timw.co/).

--- a/swapi/templates/documentation.html
+++ b/swapi/templates/documentation.html
@@ -39,6 +39,7 @@
         <li class="list-group-item"><a href="#angular">Angular</a></li>
         <li class="list-group-item"><a href="#r">R</a></li>
         <li class="list-group-item"><a href="#fsharp">F#</a></li>
+        <li class="list-group-item"><a href="#elixir">Elixir</a></li>
     </ul>
 </div>
 <div class="col-md-9 col-sm-9">


### PR DESCRIPTION
I built an Elixir wrapper for the SWAPI and wanted to add it to the list of other helpers.