### PR TITLE
Added ability to search for resources.

### DIFF
--- a/resources/tests.py
+++ b/resources/tests.py
@@ -42,6 +42,17 @@ class TestAllEndpoints(TestCase):
         self.assertEqual(
             self.get_query("/api/people/schema").status_code, 200)
 
+    def test_people_search(self):
+        response = self.get_query("/api/people/?search=r2")
+        json_data = json.loads(response.content)
+        person = People.objects.get(name='R2-D2')
+        self.assertEqual(response.status_code, 200)
+
+        list_response = self.get_query("/api/people/")
+        list_data = json.loads(list_response.content)
+        self.assertLess(json_data["count"],list_data["count"])
+        self.assertEqual(person.name, json_data["results"][0]["name"])
+
     def test_planets_root(self):
         self.assertEqual(
             self.get_query("/api/planets/").status_code, 200)
@@ -49,6 +60,17 @@ class TestAllEndpoints(TestCase):
     def test_planets_schema(self):
         self.assertEqual(
             self.get_query("/api/planets/schema").status_code, 200)
+
+    def test_planets_search(self):
+        response = self.get_query("/api/planets/?search=yavin")
+        json_data = json.loads(response.content)
+        planet = Planet.objects.get(name='Yavin IV')
+        self.assertEqual(response.status_code, 200)
+
+        list_response = self.get_query("/api/planets/")
+        list_data = json.loads(list_response.content)
+        self.assertLess(json_data["count"],list_data["count"])
+        self.assertEqual(planet.name, json_data["results"][0]["name"])
 
     def test_films_root(self):
         self.assertEqual(
@@ -58,6 +80,17 @@ class TestAllEndpoints(TestCase):
         self.assertEqual(
             self.get_query("/api/films/schema").status_code, 200)
 
+    def test_films_search(self):
+        response = self.get_query("/api/films/?search=sith")
+        json_data = json.loads(response.content)
+        film = Film.objects.get(title='Revenge of the Sith')
+        self.assertEqual(response.status_code, 200)
+
+        list_response = self.get_query("/api/films/")
+        list_data = json.loads(list_response.content)
+        self.assertLess(json_data["count"],list_data["count"])
+        self.assertEqual(film.title, json_data["results"][0]["title"])
+
     def test_starships_root(self):
         self.assertEqual(
             self.get_query("/api/starships/").status_code, 200)
@@ -65,6 +98,17 @@ class TestAllEndpoints(TestCase):
     def test_starship_schema(self):
         self.assertEqual(
             self.get_query("/api/starships/schema").status_code, 200)
+
+    def test_starship_search(self):
+        response = self.get_query("/api/starships/?search=x1")
+        json_data = json.loads(response.content)
+        ship = Starship.objects.get(name='TIE Advanced x1')
+        self.assertEqual(response.status_code, 200)
+
+        list_response = self.get_query("/api/starships/")
+        list_data = json.loads(list_response.content)
+        self.assertLess(json_data["count"],list_data["count"])
+        self.assertEqual(ship.name, json_data["results"][0]["name"])
 
     def test_vehicles_root(self):
         self.assertEqual(
@@ -74,6 +118,17 @@ class TestAllEndpoints(TestCase):
         self.assertEqual(
             self.get_query("/api/vehicles/schema").status_code, 200)
 
+    def test_vehicle_search(self):
+        response = self.get_query("/api/vehicles/?search=crawler")
+        json_data = json.loads(response.content)
+        vehicle = Vehicle.objects.get(name='Sand Crawler')
+        self.assertEqual(response.status_code, 200)
+
+        list_response = self.get_query("/api/vehicles/")
+        list_data = json.loads(list_response.content)
+        self.assertLess(json_data["count"],list_data["count"])
+        self.assertEqual(vehicle.name, json_data["results"][0]["name"])
+
     def test_species_root(self):
         self.assertEqual(
             self.get_query("/api/species/").status_code, 200)
@@ -81,6 +136,17 @@ class TestAllEndpoints(TestCase):
     def test_species_schema(self):
         self.assertEqual(
             self.get_query("/api/species/schema").status_code, 200)
+
+    def test_species_search(self):
+        response = self.get_query("/api/species/?search=calamari")
+        json_data = json.loads(response.content)
+        species = Species.objects.get(name='Mon Calamari')
+        self.assertEqual(response.status_code, 200)
+
+        list_response = self.get_query("/api/species/")
+        list_data = json.loads(list_response.content)
+        self.assertLess(json_data["count"],list_data["count"])
+        self.assertEqual(species.name, json_data["results"][0]["name"])
 
     def test_people_detail(self):
         response = self.get_query("/api/people/1/")

--- a/resources/views.py
+++ b/resources/views.py
@@ -25,6 +25,7 @@ class PeopleViewSet(viewsets.ReadOnlyModelViewSet):
 
     queryset = People.objects.all()
     serializer_class = PeopleSerializer
+    search_fields = ('name',)
 
     def retrieve(self, request, *args, **kwargs):
         return super(PeopleViewSet, self).retrieve(request, *args, **kwargs)
@@ -37,6 +38,7 @@ class PlanetViewSet(viewsets.ReadOnlyModelViewSet):
 
     queryset = Planet.objects.all()
     serializer_class = PlanetSerializer
+    search_fields = ('name',)
 
     def retrieve(self, request, *args, **kwargs):
         return super(PlanetViewSet, self).retrieve(request, *args, **kwargs)
@@ -49,6 +51,7 @@ class FilmViewSet(viewsets.ReadOnlyModelViewSet):
 
     queryset = Film.objects.all()
     serializer_class = FilmSerializer
+    search_fields = ('title',)
 
     def retrieve(self, request, *args, **kwargs):
         return super(FilmViewSet, self).retrieve(request, *args, **kwargs)
@@ -61,6 +64,7 @@ class SpeciesViewSet(viewsets.ReadOnlyModelViewSet):
 
     queryset = Species.objects.all()
     serializer_class = SpeciesSerializer
+    search_fields = ('name',)
 
     def retrieve(self, request, *args, **kwargs):
         return super(SpeciesViewSet, self).retrieve(request, *args, **kwargs)
@@ -73,6 +77,7 @@ class VehicleViewSet(viewsets.ReadOnlyModelViewSet):
 
     queryset = Vehicle.objects.all()
     serializer_class = VehicleSerializer
+    search_fields = ('name','model',)
 
     def retrieve(self, request, *args, **kwargs):
         return super(VehicleViewSet, self).retrieve(request, *args, **kwargs)
@@ -85,6 +90,7 @@ class StarshipViewSet(viewsets.ReadOnlyModelViewSet):
 
     queryset = Starship.objects.all()
     serializer_class = StarshipSerializer
+    search_fields = ('name','model',)
 
     def retrieve(self, request, *args, **kwargs):
         return super(StarshipViewSet, self).retrieve(request, *args, **kwargs)

--- a/swapi/settings.py
+++ b/swapi/settings.py
@@ -118,7 +118,10 @@ REST_FRAMEWORK = {
     ),
     'DEFAULT_THROTTLE_RATES': {
         'anon': '10000/day',
-    }
+    },
+    'DEFAULT_FILTER_BACKENDS': (
+        'rest_framework.filters.SearchFilter',
+    )
 }
 
 # Keen.io

--- a/swapi/templates/docs.md
+++ b/swapi/templates/docs.md
@@ -69,6 +69,17 @@ Swapi is a **completely open API**. No authentication is required to query and g
 
 All resources support [JSON Schema](https://jsonschema.net). Making a request to ```/api/<resource>/schema``` will give you the details of that resource. This will allow you to programmatically inspect the attributes of that resource and their types.
 
+<a name="search"></a>
+###Searching
+
+All resources support a `search` parameter that filters the set of resources returned.  This allows you to make queries like:
+
+```
+https://swapi.co/api/people/?search=r2
+```
+
+ All searches will use case-insensitive partial matches on the set of search fields. To see the set of search fields for each resource, check out the individual resource documentation. For more information on advanced search terms see [here](http://www.django-rest-framework.org/api-guide/filtering/#searchfilter).
+
 #Encodings
 - - -
 
@@ -216,6 +227,10 @@ A People resource is an individual person or character within the Star Wars univ
 - ```edited``` *string*
 -- the ISO 8601 date format of the time that this resource was edited.
 
+**Search Fields:**
+
+- ```name```
+
 - - -
 <a name="films"></a>
 ###Films
@@ -299,6 +314,10 @@ A Film resource is an single film.
 - ```edited``` *string*
 -- the ISO 8601 date format of the time that this resource was edited.
 
+**Search Fields:**
+
+- ```title```
+
 - - -
 <a name="starships"></a>
 ###Starships
@@ -381,6 +400,11 @@ A Starship resource is a single transport craft that has hyperdrive capability.
 - ```edited``` *string*
 -- the ISO 8601 date format of the time that this resource was edited.
 
+**Search Fields:**
+
+- ```name```
+- ```model```
+
 - - -
 <a name="vehicles"></a>
 ###Vehicles
@@ -457,6 +481,11 @@ A Vehicle resource is a single transport craft that **does not have** hyperdrive
 -- the ISO 8601 date format of the time that this resource was created.
 - ```edited``` *string*
 -- the ISO 8601 date format of the time that this resource was edited.
+
+**Search Fields:**
+
+- ```name```
+- ```model```
 
 - - -
 <a name="species"></a>
@@ -535,6 +564,10 @@ A Species resource is a type of person or character within the Star Wars Univers
 - ```edited``` *string*
 -- the ISO 8601 date format of the time that this resource was edited.
 
+**Search Fields:**
+
+- ```name```
+
 - - -
 <a name="planets"></a>
 ###Planets
@@ -609,6 +642,10 @@ A Planet resource is a large mass, planet or planetoid in the Star Wars Universe
 -- the ISO 8601 date format of the time that this resource was created.
 - ```edited``` *string*
 -- the ISO 8601 date format of the time that this resource was edited.
+
+**Search Fields:**
+
+- ```name```
 
 #Helper libraries
 - - -

--- a/swapi/templates/documentation.html
+++ b/swapi/templates/documentation.html
@@ -10,6 +10,7 @@
         <li class="list-group-item"><a href="#rate">Rate limiting</a></li>
         <li class="list-group-item"><a href="#auth">Authentication</a></li>
         <li class="list-group-item"><a href="#schema">JSON Schema</a></li>
+        <li class="list-group-item"><a href="#search">Searching</a></li>
     </ul>
     <h5>Encodings</h5>
     <ul class="list-group">


### PR DESCRIPTION
This should close #20, I figure it's a little more flexible than the field filtering of `DjangoFilterBackend`, which requires exact matches.  I added support for the basic 'name' fields on each model, but we can add more, if it makes sense.

- Using REST Framework’s SearchFilter, added support for searching for 
resources.
- Added docs explaining how to search and the fields on each resources 
that are searchable.
- Added basic tests for using the search param.