### PR TITLE
Allow sorting results

### DIFF
--- a/swapi/settings.py
+++ b/swapi/settings.py
@@ -121,6 +121,7 @@ REST_FRAMEWORK = {
     },
     'DEFAULT_FILTER_BACKENDS': (
         'rest_framework.filters.SearchFilter',
+        'rest_framework.filters.OrderingFilter',
     )
 }
 


### PR DESCRIPTION
Enabling the OrderingFilter class allows using the `?ordering=` param in the url.

http://djangorestframework.readthedocs.io/en/latest/api-guide/filtering/#orderingfilter