### PR TITLE
HTTPS-ify swapi.co

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # SWAPI
 ## The Star Wars API
 
-Source code for [swapi.co](http://swapi.co)
+Source code for [swapi.co](https://swapi.co)
 
 [![Circle CI](https://circleci.com/gh/phalt/swapi.svg?style=svg)](https://circleci.com/gh/phalt/swapi)
 

--- a/swapi/templates/base.html
+++ b/swapi/templates/base.html
@@ -26,7 +26,7 @@
         <span class="icon-bar"></span>
         <span class="icon-bar"></span>
       </button>
-      <div class="navbar-brand" href="#"><a href="https://twitter.com/share" class="twitter-share-button" data-url="http://swapi.co" data-text="SWAPI - the Star Wars API " data-via="phalt_" data-related="phalt_">Tweet</a>
+      <div class="navbar-brand" href="#"><a href="https://twitter.com/share" class="twitter-share-button" data-url="https://swapi.co" data-text="SWAPI - the Star Wars API " data-via="phalt_" data-related="phalt_">Tweet</a>
             <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script></div>
     </div>
     <div class="collapse navbar-collapse">

--- a/swapi/templates/docs.md
+++ b/swapi/templates/docs.md
@@ -31,14 +31,14 @@ Here is the response we get:
         "orbital_period": "304",
         "population": "200000",
         "residents": [
-            "http://swapi.co/api/people/1/",
-            "http://swapi.co/api/people/2/",
+            "https://swapi.co/api/people/1/",
+            "https://swapi.co/api/people/2/",
             ...
         ],
         "rotation_period": "23",
         "surface_water": "1",
         "terrain": "Dessert",
-        "url": "http://swapi.co/api/planets/1/"
+        "url": "https://swapi.co/api/planets/1/"
     }
 
 If your response looks slightly different don't panic. This is probably because more data has been added to swapi since we made this documentation.
@@ -50,7 +50,7 @@ The **Base URL** is the root URL for all of the API, if you ever make a request 
 
 The Base URL for swapi is:
 
-    http://swapi.co/api/
+    https://swapi.co/api/
 
 The documentation below assumes you are prepending the Base URL to the endpoints in order to make requests.
 
@@ -111,19 +111,19 @@ The Root resource provides information on all available resources within the API
 
 **Example request:**
 
-    http http://swapi.co/api/
+    http https://swapi.co/api/
 
 **Example response:**
 
     HTTP/1.0 200 OK
     Content-Type: application/json
     {
-        "films": "http://swapi.co/api/films/",
-        "people": "http://swapi.co/api/people/",
-        "planets": "http://swapi.co/api/planets/",
-        "species": "http://swapi.co/api/species/",
-        "starships": "http://swapi.co/api/starships/",
-        "vehicles": "http://swapi.co/api/vehicles/"
+        "films": "https://swapi.co/api/films/",
+        "people": "https://swapi.co/api/people/",
+        "planets": "https://swapi.co/api/planets/",
+        "species": "https://swapi.co/api/species/",
+        "starships": "https://swapi.co/api/starships/",
+        "vehicles": "https://swapi.co/api/vehicles/"
     }
 
 **Attributes:**
@@ -156,7 +156,7 @@ A People resource is an individual person or character within the Star Wars univ
 
 **Example request:**
 
-    http http://swapi.co/api/people/1/
+    http https://swapi.co/api/people/1/
 
 **Example response:**
 
@@ -166,28 +166,28 @@ A People resource is an individual person or character within the Star Wars univ
         "birth_year": "19 BBY",
         "eye_color": "Blue",
         "films": [
-            "http://swapi.co/api/films/1/",
+            "https://swapi.co/api/films/1/",
             ...
         ],
         "gender": "Male",
         "hair_color": "Blond",
         "height": "172",
-        "homeworld": "http://swapi.co/api/planets/1/",
+        "homeworld": "https://swapi.co/api/planets/1/",
         "mass": "77",
         "name": "Luke Skywalker",
         "skin_color": "Fair",
         "created": "2014-12-09T13:50:51.644000Z",
         "edited": "2014-12-10T13:52:43.172000Z",
         "species": [
-            "http://swapi.co/api/species/1/"
+            "https://swapi.co/api/species/1/"
         ],
         "starships": [
-            "http://swapi.co/api/starships/12/",
+            "https://swapi.co/api/starships/12/",
             ...
         ],
-        "url": "http://swapi.co/api/people/1/",
+        "url": "https://swapi.co/api/people/1/",
         "vehicles": [
-            "http://swapi.co/api/vehicles/14/"
+            "https://swapi.co/api/vehicles/14/"
             ...
         ]
     }
@@ -245,7 +245,7 @@ A Film resource is a single film.
 
 **Example request:**
 
-    http http://swapi.co/api/films/1/
+    http https://swapi.co/api/films/1/
 
 **Example response:**
 
@@ -253,7 +253,7 @@ A Film resource is a single film.
     Content-Type: application/json
     {
         "characters": [
-            "http://swapi.co/api/people/1/",
+            "https://swapi.co/api/people/1/",
             ...
         ],
         "created": "2014-12-10T14:23:31.880000Z",
@@ -262,23 +262,23 @@ A Film resource is a single film.
         "episode_id": 4,
         "opening_crawl": "It is a period of civil war.\n\nRebel spaceships, striking\n\nfrom a hidden base, have won\n\ntheir first victory against\n\nthe evil Galactic Empire.\n\n\n\nDuring the battle, Rebel\n\nspies managed to steal secret\r\nplans to the Empire's\n\nultimate weapon, the DEATH\n\nSTAR, an armored space\n\nstation with enough power\n\nto destroy an entire planet.\n\n\n\nPursued by the Empire's\n\nsinister agents, Princess\n\nLeia races home aboard her\n\nstarship, custodian of the\n\nstolen plans that can save her\n\npeople and restore\n\nfreedom to the galaxy....",
         "planets": [
-            "http://swapi.co/api/planets/1/",
+            "https://swapi.co/api/planets/1/",
             ...
         ],
         "producer": "Gary Kurtz, Rick McCallum",
         "release_date": "1977-05-25",
         "species": [
-            "http://swapi.co/api/species/1/",
+            "https://swapi.co/api/species/1/",
             ...
         ],
         "starships": [
-            "http://swapi.co/api/starships/2/",
+            "https://swapi.co/api/starships/2/",
             ...
         ],
         "title": "A New Hope",
-        "url": "http://swapi.co/api/films/1/",
+        "url": "https://swapi.co/api/films/1/",
         "vehicles": [
-            "http://swapi.co/api/vehicles/4/",
+            "https://swapi.co/api/vehicles/4/",
             ...
         ]
     }
@@ -332,7 +332,7 @@ A Starship resource is a single transport craft that has hyperdrive capability.
 
 **Example request:**
 
-    http http://swapi.co/api/starships/9/
+    http https://swapi.co/api/starships/9/
 
 **Example response:**
 
@@ -354,11 +354,11 @@ A Starship resource is a single transport craft that has hyperdrive capability.
         "name": "Death Star",
         "passengers": "843342",
         "films": [
-            "http://swapi.co/api/films/1/"
+            "https://swapi.co/api/films/1/"
         ],
         "pilots": [],
         "starship_class": "Deep Space Mobile Battlestation",
-        "url": "http://swapi.co/api/starships/9/"
+        "url": "https://swapi.co/api/starships/9/"
     }
 
 **Attributes:**
@@ -419,7 +419,7 @@ A Vehicle resource is a single transport craft that **does not have** hyperdrive
 
 **Example request:**
 
-    http http://swapi.co/api/vehicles/4/
+    http https://swapi.co/api/vehicles/4/
 
 **Example response:**
 
@@ -441,9 +441,9 @@ A Vehicle resource is a single transport craft that **does not have** hyperdrive
         "passengers": "30",
         "pilots": [],
         "films": [
-            "http://swapi.co/api/films/1/"
+            "https://swapi.co/api/films/1/"
         ],
-        "url": "http://swapi.co/api/vehicles/4/",
+        "url": "https://swapi.co/api/vehicles/4/",
         "vehicle_class": "wheeled"
     }
 
@@ -501,7 +501,7 @@ A Species resource is a type of person or character within the Star Wars Univers
 
 **Example request:**
 
-    http http://swapi.co/api/species/3/
+    http https://swapi.co/api/species/3/
 
 **Example response:**
 
@@ -517,18 +517,18 @@ A Species resource is a type of person or character within the Star Wars Univers
         "edited": "2014-12-10T16:44:31.486000Z",
         "eye_colors": "blue, green, yellow, brown, golden, red",
         "hair_colors": "black, brown",
-        "homeworld": "http://swapi.co/api/planets/14/",
+        "homeworld": "https://swapi.co/api/planets/14/",
         "language": "Shyriiwook",
         "name": "Wookie",
         "people": [
-            "http://swapi.co/api/people/13/"
+            "https://swapi.co/api/people/13/"
         ],
         "films": [
-            "http://swapi.co/api/films/1/",
-            "http://swapi.co/api/films/2/"
+            "https://swapi.co/api/films/1/",
+            "https://swapi.co/api/films/2/"
         ],
         "skin_colors": "gray",
-        "url": "http://swapi.co/api/species/3/"
+        "url": "https://swapi.co/api/species/3/"
     }
 
 **Attributes:**
@@ -582,7 +582,7 @@ A Planet resource is a large mass, planet or planetoid in the Star Wars Universe
 
 **Example request:**
 
-    http http://swapi.co/api/planets/1/
+    http https://swapi.co/api/planets/1/
 
 **Example response:**
 
@@ -595,7 +595,7 @@ A Planet resource is a large mass, planet or planetoid in the Star Wars Universe
         "diameter": "10465",
         "edited": "2014-12-15T13:48:16.167217Z",
         "films": [
-            "http://swapi.co/api/films/1/",
+            "https://swapi.co/api/films/1/",
             ...
         ],
         "gravity": "1",
@@ -603,13 +603,13 @@ A Planet resource is a large mass, planet or planetoid in the Star Wars Universe
         "orbital_period": "304",
         "population": "120000",
         "residents": [
-            "http://swapi.co/api/people/1/",
+            "https://swapi.co/api/people/1/",
             ...
         ],
         "rotation_period": "23",
         "surface_water": "1",
         "terrain": "Dessert",
-        "url": "http://swapi.co/api/planets/1/"
+        "url": "https://swapi.co/api/planets/1/"
     }
 
 **Attributes:**

--- a/swapi/templates/index.html
+++ b/swapi/templates/index.html
@@ -23,7 +23,7 @@
             Try it now!
         </h1>
         <div class="input-group">
-              <span class="input-group-addon">http://swapi.co/api/</span>
+              <span class="input-group-addon">https://swapi.co/api/</span>
               <input id="interactive" type="text" class="form-control" placeholder="people/1/">
               <span class="input-group-btn"><button onClick="interactive_call();return false;" class="btn btn-primary">request</button></span>
             </div>
@@ -32,34 +32,36 @@
         <div class="well">
           <pre id="interactive_output" class="pre-scrollable">
 {
-      "name": "Luke Skywalker",
-      "height": "1.72 m",
-      "mass": "77 Kg",
-      "hair_color": "Blond",
-      "skin_color": "Caucasian",
-      "eye_color": "Blue",
-      "birth_year": "19 BBY",
-      "gender": "Male",
-      "homeworld": "http://swapi.co/api/planets/1/",
-      "films": [
-          "http://swapi.co/api/films/1/",
-          "http://swapi.co/api/films/2/",
-          "http://swapi.co/api/films/3/"
-      ],
-      "species": [
-          "http://swapi.co/api/species/1/"
-      ],
-      "vehicles": [
-          "http://swapi.co/api/vehicles/14/",
-          "http://swapi.co/api/vehicles/30/"
-      ],
-      "starships": [
-          "http://swapi.co/api/starships/12/",
-          "http://swapi.co/api/starships/22/"
-      ],
-      "created": "2014-12-09T13:50:51.644000Z",
-      "edited": "2014-12-10T13:52:43.172000Z",
-      "url": "http://swapi.co/api/people/1/"
+	"name": "Luke Skywalker",
+	"height": "172",
+	"mass": "77",
+	"hair_color": "blond",
+	"skin_color": "fair",
+	"eye_color": "blue",
+	"birth_year": "19BBY",
+	"gender": "male",
+	"homeworld": "https://swapi.co/api/planets/1/",
+	"films": [
+		"https://swapi.co/api/films/2/",
+		"https://swapi.co/api/films/6/",
+		"https://swapi.co/api/films/3/",
+		"https://swapi.co/api/films/1/",
+		"https://swapi.co/api/films/7/"
+	],
+	"species": [
+		"https://swapi.co/api/species/1/"
+	],
+	"vehicles": [
+		"https://swapi.co/api/vehicles/14/",
+		"https://swapi.co/api/vehicles/30/"
+	],
+	"starships": [
+		"https://swapi.co/api/starships/12/",
+		"https://swapi.co/api/starships/22/"
+	],
+	"created": "2014-12-09T13:50:51.644000Z",
+	"edited": "2014-12-20T21:17:56.891000Z",
+	"url": "https://swapi.co/api/people/1/"
 }
           </pre>
         </div>

--- a/swapi/templates/rest_framework/api.html
+++ b/swapi/templates/rest_framework/api.html
@@ -12,7 +12,7 @@
 <span class="icon-bar"></span>
 <span class="icon-bar"></span>
 </button>
-<div class="navbar-brand" href="#"><a href="https://twitter.com/share" class="twitter-share-button" data-url="http://swapi.co" data-text="SWAPI - the Star Wars API " data-via="phalt_" data-related="phalt_">Tweet</a>
+<div class="navbar-brand" href="#"><a href="https://twitter.com/share" class="twitter-share-button" data-url="https://swapi.co" data-text="SWAPI - the Star Wars API " data-via="phalt_" data-related="phalt_">Tweet</a>
     <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script></div>
 </div>
 <div class="collapse navbar-collapse">


### PR DESCRIPTION
As noted in #90, neither the index site (1) nor the documentation (2) nor the URLs in swapi’s responses show HTTPS protocols (3).

This PR updates all http://swapi.co URLs to point to https://swapi.co. Additionally, I updated the demo request on the index site to show the current (but HTTPS-ified request). This is the first step and should fix (1) and (2).

In order to fix the URLs in the API responses (3), you have to change CloudFlare’s SSL settings to “full” instead of “flexible”. (Make sure you used your `*.herokuapp.com` URL in the CNAME record, as [shown here](https://support.cloudflare.com/hc/en-us/articles/205893698-Configure-Cloudflare-and-Heroku-over-HTTPS).) As a result, the `X-Forwarded-Proto` header should be set and Gunicorn should rewrite all response URLs automatically to HTTPS. If the user calls the API via HTTP, they will still see the HTTP references in the response. If this is fixed, #90 should be closed.

![image](https://user-images.githubusercontent.com/6698344/28478571-470f7786-6e59-11e7-80d1-189c1c42f64b.png)