### PR TITLE
Replaced "homeworld": null with "homeworld": "n/a" in species.json

### DIFF
--- a/resources/fixtures/species.json
+++ b/resources/fixtures/species.json
@@ -40,7 +40,7 @@
         "skin_colors": "n/a",
         "language": "n/a",
         "hair_colors": "n/a",
-        "homeworld": null,
+        "homeworld": "n/a",
         "average_lifespan": "indefinite",
         "average_height": "n/a"
     },


### PR DESCRIPTION
Replaced `"homeworld": null` with `"homeworld": "n/a"` for species 2 to be consistent with the rest of the API.

I don't believe the null was intended. In my case it actually broke the wrapper I've been writing since I hadn't seen any other null types come through. 