### PR TITLE
Removed SWAPI-JAVA client from documentation.

### DIFF
--- a/swapi/templates/docs.md
+++ b/swapi/templates/docs.md
@@ -670,11 +670,6 @@ There are a bunch of helper libraries available for consuming the Star Wars API 
 
 - [SWAPI-Android-SDK](https://github.com/Oleur/SWAPI-Android-SDK) by [Julien Salvi](https://github.com/Oleur).
 
-<a name="java"></a>
-##Java
-
-- [swapi-java](https://github.com/TheNightPhoenix/SWAPI-JAVA) by [Abdallah Hodieb](https://github.com/TheNightPhoenix).
-
 <a name="golang"></a>
 ##Go
 


### PR DESCRIPTION
Removed reference to [SWAPI-JAVA](https://github.com/TheNightPhoenix/SWAPI-JAVA) client from documentation because it no longer exists.