### PR TITLE
Add swapi-android client library

### DIFF
--- a/swapi/templates/docs.md
+++ b/swapi/templates/docs.md
@@ -669,6 +669,7 @@ There are a bunch of helper libraries available for consuming the Star Wars API 
 ##Android
 
 - [SWAPI-Android-SDK](https://github.com/Oleur/SWAPI-Android-SDK) by [Julien Salvi](https://github.com/Oleur).
+- [swapi-android (with Kotlin Coroutines)](https://github.com/gotev/swapi-android) by [Alex Gotev](https://github.com/gotev)
 
 <a name="java"></a>
 ##Java


### PR DESCRIPTION
This adds a reference to the SWAPI Android SDK Project, written in Kotlin and using Coroutines. It's not only a client SDK, but also hosts a complete SWAPI.co API Mirror, to reduce loads on SWAPI.co. The client SDK points by default to the Mirrored API.